### PR TITLE
Fixed old parser build error.

### DIFF
--- a/Src/Core/API/Base/Factory.cs
+++ b/Src/Core/API/Base/Factory.cs
@@ -17,8 +17,6 @@
 
         private static readonly char[] Whitespaces = new char[] { ' ', '\t', '\n' };
 
-        private static bool USE_ANTLR = true;
-
         public static Factory Instance
         {
             get { return instance; }
@@ -1368,17 +1366,15 @@
             return Task.Factory.StartNew<ParseResult>(() =>
             {
                 ParseResult pr;
-                if (USE_ANTLR)
-                {
-                    var parser = new FormulaVisitor();
-                    parser.ParseFile(name, null, default(Span), cancelToken, out pr);
-                }
-                else
-                {
-                    var parser = new Parser(envParams);
-                    parser.ParseFile(name, null, default(Span), cancelToken, out pr);
-                }
-                
+
+#if USE_ANTLR
+                var antlr_parser = new FormulaVisitor();
+                antlr_parser.ParseFile(name, null, default(Span), cancelToken, out pr);
+#else
+                var parser = new Parser(envParams);
+                parser.ParseFile(name, null, default(Span), cancelToken, out pr);
+#endif
+
                 return pr;
             });
         }
@@ -1393,16 +1389,14 @@
             return Task.Factory.StartNew<ParseResult>(() =>
             {
                 ParseResult pr;
-                if (USE_ANTLR)
-                {
-                    var parser = new FormulaVisitor();
-                    parser.ParseText(name, programText, default(Span), cancelToken, out pr);
-                }
-                else
-                {
-                    var parser = new Parser(envParams);
-                    parser.ParseText(name, programText, default(Span), cancelToken, out pr);
-                }
+
+#if USE_ANTLR
+                var antlr_parser = new FormulaVisitor();
+                antlr_parser.ParseText(name, programText, default(Span), cancelToken, out pr);
+#else
+                var parser = new Parser(envParams);
+                parser.ParseText(name, programText, default(Span), cancelToken, out pr);
+#endif
 
                 return pr;
             });
@@ -1418,16 +1412,15 @@
             return Task.Factory.StartNew<ParseResult>(() =>
             {
                 ParseResult pr;
-                if (USE_ANTLR)
-                {
-                    var parser = new FormulaVisitor();
-                    parser.ParseFile(name, referrer, location, cancelToken, out pr);
-                }
-                else
-                {
-                    var parser = new Parser(envParams);
-                    parser.ParseFile(name, referrer, location, cancelToken, out pr);
-                }
+
+#if USE_ANTLR
+                var antlr_parser = new FormulaVisitor();
+                antlr_parser.ParseFile(name, referrer, location, cancelToken, out pr);
+#else
+                var parser = new Parser(envParams);
+                parser.ParseFile(name, referrer, location, cancelToken, out pr);
+#endif
+
                 return pr;
             });
         }
@@ -1437,16 +1430,14 @@
             Contract.Requires(text != null);
             ParseResult pr;
             AST<Node> result = null;
-            if (USE_ANTLR)
-            {
-                var parser = new FormulaVisitor();
-                result = parser.ParseFuncTerm(text, out pr);
-            }
-            else
-            {
-                var parser = new Parser(envParams);
-                result = parser.ParseFuncTerm(text, out pr);
-            }
+
+#if USE_ANTLR
+            var parser = new FormulaVisitor();
+            result = parser.ParseFuncTerm(text, out pr);
+#else
+            var parser = new Parser(envParams);
+            result = parser.ParseFuncTerm(text, out pr);
+#endif
 
             pr.Program.Root.GetNodeHash();
             flags = pr.Flags;

--- a/Src/Core/Core.csproj
+++ b/Src/Core/Core.csproj
@@ -3,19 +3,28 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-      <TargetFrameworkIdentifier>.NETCOREAPP</TargetFrameworkIdentifier>
-      <TargetFrameworkVersion>6.0</TargetFrameworkVersion>
-      <Platforms>ARM64;x64</Platforms>
-      <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-      <Platform Condition="'$(Platform)' == ''">x64</Platform>
-      <PlatformTarget Condition="'$(Platform)' == 'x64'">x64</PlatformTarget>
-      <PlatformTarget Condition="'$(Platform)' == 'ARM64'">arm64</PlatformTarget>
-      <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin/</BaseOutputPath>
-      <OutputPath Condition="'$(OutputPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">$(BaseOutputPath)$(Configuration)/Windows/$(Platform)/</OutputPath>
-      <OutputPath Condition="'$(OutputPath)' == '' and $([MSBuild]::IsOSPlatform('Linux'))">$(BaseOutputPath)$(Configuration)/Linux/$(Platform)/</OutputPath>
-      <OutputPath Condition="'$(OutputPath)' == '' and $([MSBuild]::IsOSPlatform('MacOS'))">$(BaseOutputPath)$(Configuration)/MacOS/$(Platform)/</OutputPath>
-      <RootNamespace>Microsoft.Formula</RootNamespace>
+    <TargetFrameworkIdentifier>.NETCOREAPP</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>6.0</TargetFrameworkVersion>
+    <Platforms>ARM64;x64</Platforms>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
+    <PlatformTarget Condition="'$(Platform)' == 'x64'">x64</PlatformTarget>
+    <PlatformTarget Condition="'$(Platform)' == 'ARM64'">arm64</PlatformTarget>
+    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin/</BaseOutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">$(BaseOutputPath)$(Configuration)/Windows/$(Platform)/</OutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and $([MSBuild]::IsOSPlatform('Linux'))">$(BaseOutputPath)$(Configuration)/Linux/$(Platform)/</OutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and $([MSBuild]::IsOSPlatform('MacOS'))">$(BaseOutputPath)$(Configuration)/MacOS/$(Platform)/</OutputPath>
+    <RootNamespace>Microsoft.Formula</RootNamespace>
+    <DefineConstants>USE_ANTLR</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="API/Parser/lexer.lex" />
+    <Compile Remove="API/Parser/lexer.g.cs" />
+    <Compile Remove="API/Parser/parser.g.cs" />
+    <None Remove="API/Parser/parser.y" />
+    <Compile Remove="API/Parser/Parser.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="Common\Terms\CanUnnDef.cs" />


### PR DESCRIPTION
Fixed the build errors when trying to load the old parser files in Core/API. The files are still in the directory but excluded in the csproj file. A preprocessor variable was added to skip loading the old code. Remove the constant and include the files in Core.csproj to use the old parser.